### PR TITLE
Reduced Message Size

### DIFF
--- a/src/message_structs.rs
+++ b/src/message_structs.rs
@@ -34,6 +34,7 @@ impl InitMessage {
 #[derive(Serialize, Deserialize, Clone)]
 pub enum UserMessage {
     Basic(BasicMessage),
+    TSBasic(TSBasicMessage),
     Image(ImageMessage),
     Notification(NotificationMessage),
     Typing(TypingMessage),
@@ -62,6 +63,11 @@ pub struct BasicMessage {
     pub message_id: String,
     pub room_id: String,
     pub ws_id: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TSBasicMessage {
+    pub content: String,
 }
 
 // ImageMessage Struct

--- a/static/JS/ws.js
+++ b/static/JS/ws.js
@@ -14,6 +14,7 @@ let user_map = {};
 let ws_id = "";
 let username = "";
 let current_room = "";
+let room_map = {};
 let socket;
 var MessageType;
 (function (MessageType) {
@@ -219,18 +220,13 @@ document.getElementById('Message').addEventListener('submit', function (event) {
 });
 function send_message() {
     const textarea = document.querySelector('textarea[name="message_form"]');
-    const messageContent = textarea.value.trim();
-    if (messageContent !== '') {
+    const message_content = textarea.value.trim();
+    if (message_content !== '') {
         const basic_message = {
-            content: messageContent,
-            sender_id: sender_id,
-            message_id: "",
-            room_id: current_room,
-            ws_id: ws_id,
-            timestamp: Date.now(),
+            content: message_content,
         };
         const wrappedMessage = {
-            Basic: basic_message
+            TSBasic: basic_message
         };
         if (socket.readyState === WebSocket.OPEN) {
             socket.send(JSON.stringify(wrappedMessage));
@@ -244,7 +240,7 @@ function send_message() {
         messageWrapper.classList.add('chat-message', 'sent-message');
         usernameElement.textContent = username + ':';
         usernameElement.classList.add('username');
-        messageElement.textContent = messageContent;
+        messageElement.textContent = message_content;
         messageWrapper.appendChild(usernameElement);
         messageWrapper.appendChild(messageElement);
         const checkbox = document.createElement('input');

--- a/static/TS/ws.ts
+++ b/static/TS/ws.ts
@@ -38,6 +38,10 @@ interface BasicMessage {
     timestamp: number;
 }
 
+interface TSBasicMessage {
+    content: string;
+}
+
 interface ImageMessage {
     image_url: string;
     sender_id: string;
@@ -88,6 +92,7 @@ interface DeletionMessage {
 
 type UserMessage =
     | { Basic: BasicMessage }
+    | { TSBasic: TSBasicMessage }
     | { Image: ImageMessage }
     | { Notification: NotificationMessage }
     | { Typing: TypingMessage }
@@ -317,19 +322,14 @@ document.getElementById('Message')!.addEventListener('submit', function(event: E
 
 function send_message(): void {
     const textarea: HTMLTextAreaElement = document.querySelector('textarea[name="message_form"]')!;
-    const messageContent: string = textarea.value.trim();
-    if (messageContent !== '') {
-        const basic_message: BasicMessage = {
-            content: messageContent,
-            sender_id: sender_id,
-            message_id: "",
-            room_id: current_room,
-            ws_id: ws_id,
-            timestamp: Date.now(),
+    const message_content: string = textarea.value.trim();
+    if (message_content !== '') {
+        const basic_message: TSBasicMessage = {
+            content: message_content,
         };
     
         const wrappedMessage: UserMessage = {
-            Basic: basic_message
+            TSBasic: basic_message
         };
     
         if (socket.readyState === WebSocket.OPEN) {
@@ -346,7 +346,7 @@ function send_message(): void {
         
         usernameElement.textContent = username + ':';
         usernameElement.classList.add('username');
-        messageElement.textContent = messageContent;
+        messageElement.textContent = message_content;
         
         messageWrapper.appendChild(usernameElement);
         messageWrapper.appendChild(messageElement);


### PR DESCRIPTION
This pull request makes a change to the way messages are sent from the client to the server. Previously, when a client sent a message, it included not only the content of the message but also additional metadata such as the time the message was sent and the user ID of the sender. The proposed change in this pull request is to simplify the messages sent from the client so that they only contain the message content itself. Any extra metadata, including the time the message was sent and the user ID, will now be added by the server when it receives the message. This approach reduces the size of the data the client needs to send, potentially improving performance and efficiency.